### PR TITLE
chore: fix typos `messsage` → `message`

### DIFF
--- a/crates/biome_configuration/src/diagnostics.rs
+++ b/crates/biome_configuration/src/diagnostics.rs
@@ -279,10 +279,10 @@ impl CantLoadExtendFile {
         }
     }
 
-    pub fn with_verbose_advice(mut self, messsage: impl Display) -> Self {
+    pub fn with_verbose_advice(mut self, message: impl Display) -> Self {
         self.verbose_advice
             .messages
-            .push(markup! {{messsage}}.to_owned());
+            .push(markup! {{message}}.to_owned());
         self
     }
 }
@@ -345,10 +345,10 @@ impl CantResolve {
         }
     }
 
-    pub fn with_verbose_advice(mut self, messsage: impl Display) -> Self {
+    pub fn with_verbose_advice(mut self, message: impl Display) -> Self {
         self.verbose_advice
             .messages
-            .push(markup! {{messsage}}.to_owned());
+            .push(markup! {{message}}.to_owned());
         self
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Correct misspelled parameter name `messsage` to `message` in `with_verbose_advice` methods of diagnostic types

Chores:
- Fix typo in method signature and usage for CantLoadExtendFile.with_verbose_advice
- Fix typo in method signature and usage for CantResolve.with_verbose_advice